### PR TITLE
Add tablet registration tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 l'application de gestion des tablettes de l'enquête pédagogique. L'onglet
 **Affectation** permet de saisir le nom du bénéficiaire, son identifiant et la
 date d'affectation.
+L'onglet **Enregistrement** permet d'ajouter une nouvelle tablette en
+précisant si un chargeur et une powerbank sont présents.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- extend README documentation
- add charger and powerbank columns
- allow importing or loading tablets with new columns
- add a new `ajouter_tablette` function
- create an "Enregistrement" tab for adding tablets via the UI

## Testing
- `python -m py_compile app_tablettes.py`

------
https://chatgpt.com/codex/tasks/task_e_6848bcdbf0048325874b47a590d7574b