### PR TITLE
Ajout génération de fiches et affectation auto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pandas
 openpyxl
+python-docx
+docx2pdf


### PR DESCRIPTION
## Summary
- génère des fiches d'affectation Word et PDF
- ajoute la fonction d'affectation automatique depuis deux fichiers Excel
- ouvre le dossier des fiches via l'interface
- met à jour les dépendances

## Testing
- `python -m py_compile app_tablettes.py`

------
https://chatgpt.com/codex/tasks/task_e_6849b42e26848325a29965b9d7cea0cc