### PR TITLE
Fix quoting in Stata scenario loop

### DIFF
--- a/code_prj_1.do
+++ b/code_prj_1.do
@@ -84,5 +84,5 @@ local cond7 "if elder==1"
 local cond8 "if handicap==1"
 forvalues i=1/8 {
     local nm : word `i' of `names'
-    run_sce "`nm'" ``cond`i''
+    run_sce "`nm'" "`cond`i''"
 }


### PR DESCRIPTION
## Summary
- ensure scenario conditions containing spaces are passed correctly by quoting argument

## Testing
- `pytest -q` *(fails: no tests ran)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b8655dd08325b4e055ca05949bfb