### PR TITLE
Add standalone poster creator web page

### DIFF
--- a/poster_creator/README.md
+++ b/poster_creator/README.md
@@ -1,11 +1,18 @@
-# Générateur d'affiche personnalisée
+# Poster Creator
 
-Cette page HTML permet d'ajouter une photo sur un modèle d'affiche puis de télécharger l'image finale. Elle peut être déployée facilement via GitHub Pages car elle ne nécessite aucun serveur.
+This simple static page lets you overlay your own photo onto a predefined poster image directly in the browser. Everything runs client side so it can be deployed easily with GitHub Pages.
 
-## Utilisation
+## Usage
 
-1. Placez votre affiche vierge (sans photo) dans ce dossier et nommez le fichier **`poster.png`**.
-2. Ouvrez `index.html` dans votre navigateur ou déployez le dossier avec GitHub Pages.
-3. Importez votre photo via le bouton prévu, déplacez-la sur l'affiche, ajustez la taille puis cliquez sur **Télécharger** pour récupérer l'image générée.
+1. Place your poster template image **`poster.png`** in this folder.
+2. Open `index.html` in a browser or deploy the folder with GitHub Pages.
+3. Upload a photo with the file input, drag it to position, adjust its size with the slider, then click **Download** to save the final poster.
 
-La page s'appuie entièrement sur du JavaScript côté client ; aucune donnée n'est envoyée vers un serveur.
+## Deploy on GitHub Pages
+
+1. Create a new repository and add the files of this folder (including your `poster.png`).
+2. Commit and push to GitHub.
+3. In the repository settings, enable **GitHub Pages** and select the branch containing these files (typically `main`) and the **root** folder.
+4. After a few seconds a public URL will be provided where the page is available.
+
+No server is required; all processing is done in JavaScript in the browser.

--- a/poster_creator/index.html
+++ b/poster_creator/index.html
@@ -1,104 +1,21 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Générateur d'affiche personnalisée</title>
-<style>
-  body { font-family: Arial, sans-serif; text-align: center; }
-  canvas { border: 1px solid #ccc; margin-top: 10px; cursor: grab; }
-  #controls { margin-top: 10px; }
-</style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Générateur d'affiche personnalisée</title>
+  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-<h1>Générateur d'affiche personnalisée</h1>
-<p>Ajoutez votre photo puis déplacez-la sur l'affiche. Utilisez la barre pour ajuster la taille et téléchargez l'image finale.</p>
-<input type="file" id="photoInput" accept="image/*"><br>
-<label for="scaleRange">Zoom photo :</label>
-<input type="range" id="scaleRange" min="0.1" max="2" step="0.01" value="1">
-<div id="controls">
-  <button id="downloadBtn">Télécharger</button>
-</div>
-<canvas id="posterCanvas" width="600" height="800"></canvas>
-<script>
-const canvas = document.getElementById('posterCanvas');
-const ctx = canvas.getContext('2d');
-const basePoster = new Image();
-basePoster.src = 'poster.png';
-let userImg = new Image();
-let imgX = 200, imgY = 200; // position initiale
-let imgScale = 1;
-let dragging = false;
-let offsetX = 0, offsetY = 0;
-
-function draw() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  if (basePoster.complete) {
-    ctx.drawImage(basePoster, 0, 0, canvas.width, canvas.height);
-  }
-  if (userImg.complete && userImg.src) {
-    const w = userImg.width * imgScale;
-    const h = userImg.height * imgScale;
-    ctx.drawImage(userImg, imgX, imgY, w, h);
-  }
-}
-
-basePoster.onload = draw;
-
-document.getElementById('photoInput').addEventListener('change', (e) => {
-  const file = e.target.files[0];
-  if (!file) return;
-  const reader = new FileReader();
-  reader.onload = (ev) => {
-    userImg = new Image();
-    userImg.onload = draw;
-    userImg.src = ev.target.result;
-  };
-  reader.readAsDataURL(file);
-});
-
-canvas.addEventListener('mousedown', (e) => {
-  if (!userImg.src) return;
-  const rect = canvas.getBoundingClientRect();
-  const x = e.clientX - rect.left;
-  const y = e.clientY - rect.top;
-  const w = userImg.width * imgScale;
-  const h = userImg.height * imgScale;
-  if (x >= imgX && x <= imgX + w && y >= imgY && y <= imgY + h) {
-    dragging = true;
-    offsetX = x - imgX;
-    offsetY = y - imgY;
-    canvas.style.cursor = 'grabbing';
-  }
-});
-
-canvas.addEventListener('mousemove', (e) => {
-  if (!dragging) return;
-  const rect = canvas.getBoundingClientRect();
-  imgX = e.clientX - rect.left - offsetX;
-  imgY = e.clientY - rect.top - offsetY;
-  draw();
-});
-
-canvas.addEventListener('mouseup', () => {
-  dragging = false;
-  canvas.style.cursor = 'grab';
-});
-canvas.addEventListener('mouseleave', () => { dragging = false; canvas.style.cursor = 'grab'; });
-
-document.getElementById('scaleRange').addEventListener('input', (e) => {
-  imgScale = parseFloat(e.target.value);
-  draw();
-});
-
-// Télécharger l'image
-function downloadCanvas() {
-  const link = document.createElement('a');
-  link.download = 'affiche.png';
-  link.href = canvas.toDataURL('image/png');
-  link.click();
-}
-document.getElementById('downloadBtn').addEventListener('click', downloadCanvas);
-</script>
+  <h1>Générateur d'affiche personnalisée</h1>
+  <p>Ajoutez votre photo puis déplacez-la sur l'affiche. Utilisez la barre pour ajuster la taille et téléchargez l'image finale.</p>
+  <input type="file" id="photoInput" accept="image/*"><br>
+  <label for="scaleRange">Zoom photo :</label>
+  <input type="range" id="scaleRange" min="0.1" max="2" step="0.01" value="1">
+  <div id="controls">
+    <button id="downloadBtn">Télécharger</button>
+  </div>
+  <canvas id="posterCanvas" width="600" height="800"></canvas>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/poster_creator/script.js
+++ b/poster_creator/script.js
@@ -1,0 +1,82 @@
+const canvas = document.getElementById('posterCanvas');
+const ctx = canvas.getContext('2d');
+const basePoster = new Image();
+basePoster.src = 'poster.png';
+let userImg = new Image();
+let imgX = 200, imgY = 200; // initial position
+let imgScale = 1;
+let dragging = false;
+let offsetX = 0, offsetY = 0;
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  if (basePoster.complete) {
+    ctx.drawImage(basePoster, 0, 0, canvas.width, canvas.height);
+  }
+  if (userImg.complete && userImg.src) {
+    const w = userImg.width * imgScale;
+    const h = userImg.height * imgScale;
+    ctx.drawImage(userImg, imgX, imgY, w, h);
+  }
+}
+
+basePoster.onload = draw;
+
+document.getElementById('photoInput').addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (ev) => {
+    userImg = new Image();
+    userImg.onload = draw;
+    userImg.src = ev.target.result;
+  };
+  reader.readAsDataURL(file);
+});
+
+canvas.addEventListener('mousedown', (e) => {
+  if (!userImg.src) return;
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const w = userImg.width * imgScale;
+  const h = userImg.height * imgScale;
+  if (x >= imgX && x <= imgX + w && y >= imgY && y <= imgY + h) {
+    dragging = true;
+    offsetX = x - imgX;
+    offsetY = y - imgY;
+    canvas.style.cursor = 'grabbing';
+  }
+});
+
+canvas.addEventListener('mousemove', (e) => {
+  if (!dragging) return;
+  const rect = canvas.getBoundingClientRect();
+  imgX = e.clientX - rect.left - offsetX;
+  imgY = e.clientY - rect.top - offsetY;
+  draw();
+});
+
+canvas.addEventListener('mouseup', () => {
+  dragging = false;
+  canvas.style.cursor = 'grab';
+});
+
+canvas.addEventListener('mouseleave', () => {
+  dragging = false;
+  canvas.style.cursor = 'grab';
+});
+
+document.getElementById('scaleRange').addEventListener('input', (e) => {
+  imgScale = parseFloat(e.target.value);
+  draw();
+});
+
+function downloadCanvas() {
+  const link = document.createElement('a');
+  link.download = 'affiche.png';
+  link.href = canvas.toDataURL('image/png');
+  link.click();
+}
+
+document.getElementById('downloadBtn').addEventListener('click', downloadCanvas);

--- a/poster_creator/styles.css
+++ b/poster_creator/styles.css
@@ -1,0 +1,16 @@
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+}
+
+#posterCanvas {
+  border: 1px solid #ccc;
+  margin-top: 10px;
+  cursor: grab;
+}
+
+#controls {
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- restructure poster_creator page into separate HTML/CSS/JS files
- update instructions for GitHub Pages deployment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e1b093ac8325b862eeb1d200c183