### PR TITLE
Add 2023 inflation to poverty line update

### DIFF
--- a/code_prj_1.do
+++ b/code_prj_1.do
@@ -131,7 +131,7 @@ use "C:\Intel\AS2\S2\Développement et conditions de vie des ménages\EHCVM\ehcv
 * =============================================================
 replace cons_pc    = cons_pc*1.259      // adjust expenditure for inflation
 replace weight     = weight*1.153       // population growth adjustment
-foreach infl in 0.005 0.010 0.025 0.022 0.097 {
+foreach infl in 0.005 0.010 0.025 0.022 0.097 0.059 {
     replace poverty_line = poverty_line*(1+`infl')
 }
 * Restore original names before saving


### PR DESCRIPTION
## Summary
- update Stata script to apply 2023 inflation rate when adjusting the poverty line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68553479fc548325b5ac6803c96f3d28