### PR TITLE
Fix duplicate primary key in SQL schema

### DIFF
--- a/ensae/e_election_ensae (1).sql
+++ b/ensae/e_election_ensae (1).sql
@@ -444,8 +444,7 @@ INSERT INTO `vote_sessions` (`id`, `election_type_id`, `club_id`, `start_time`, 
 
 CREATE TABLE `committee_election_types` (
   `user_id` int(11) NOT NULL,
-  `election_type_id` int(11) NOT NULL,
-  PRIMARY KEY (`user_id`,`election_type_id`)
+  `election_type_id` int(11) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --


### PR DESCRIPTION
## Summary
- remove inline primary key from `committee_election_types` definition to avoid duplicate constraint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b25cf37048325a1b16152c0d927d0