### PR TITLE
Add email autocomplete for committee members

### DIFF
--- a/ensae/admin/actions.php
+++ b/ensae/admin/actions.php
@@ -775,7 +775,21 @@ try {
                 sendResponse(false, 'Membre non trouvé');
             }
             break;
-            
+
+        case 'search_emails':
+            // Rechercher les emails commençant par un terme donné
+            $term = trim($_POST['query'] ?? '');
+
+            $emails = [];
+            if ($term !== '') {
+                $stmt = $pdo->prepare("SELECT email FROM users WHERE email LIKE ? ORDER BY email LIMIT 10");
+                $stmt->execute(["{$term}%"]);
+                $emails = $stmt->fetchAll(PDO::FETCH_COLUMN);
+            }
+
+            sendResponse(true, 'Liste des emails', $emails);
+            break;
+
         default:
             sendResponse(false, 'Action non reconnue');
             break;


### PR DESCRIPTION
## Summary
- add `search_emails` action in admin `actions.php`
- add suggestions dropdown for email input in `committees.php`
- implement JS to fetch suggestions while typing
- style suggestions dropdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b29280e588325867f5c1277c9694e