### PR TITLE
Implement committee privilege controls

### DIFF
--- a/ensae/admin/profil.php
+++ b/ensae/admin/profil.php
@@ -1,6 +1,10 @@
 <?php
 require_once('../config/database.php');
-requireRole('admin'); // Les membres de comité sont aussi acceptés
+requireLogin();
+if (!hasRole('admin') && !hasRole('committee')) {
+    header('Location: ../login.php');
+    exit();
+}
 
 $user = getCurrentUser();
 if (!$user) {
@@ -12,6 +16,22 @@ if (!$user) {
 $stmt = $pdo->prepare("SELECT * FROM activity_logs WHERE user_id = ? ORDER BY created_at DESC LIMIT 15");
 $stmt->execute([$user['id']]);
 $logs = $stmt->fetchAll();
+
+// Types d'élections accessibles
+if ($user['role'] === 'admin') {
+    $stmt = $pdo->query("SELECT id, name FROM election_types WHERE is_active = 1 ORDER BY name");
+    $election_types = $stmt->fetchAll();
+} else {
+    $stmt = $pdo->prepare("SELECT et.id, et.name FROM election_types et JOIN committee_election_types cet ON et.id = cet.election_type_id WHERE et.is_active = 1 AND cet.user_id = ? ORDER BY et.name");
+    $stmt->execute([$user['id']]);
+    $election_types = $stmt->fetchAll();
+}
+
+// Clubs pour les sessions
+$stmt = $pdo->query("SELECT id, name FROM clubs WHERE is_active = 1 ORDER BY name");
+$clubs = $stmt->fetchAll();
+
+$is_committee = in_array($user['role'], ['admin', 'committee']);
 ?>
 <!DOCTYPE html>
 <html lang="fr">
@@ -153,6 +173,51 @@ $logs = $stmt->fetchAll();
         border-bottom: none;
     }
 
+    .committee-actions {
+        margin-top: 2rem;
+        padding: 1.5rem;
+        background: linear-gradient(135deg, #667eea, #764ba2);
+        border-radius: 10px;
+        color: white;
+    }
+
+    .committee-actions h3 {
+        text-align: center;
+        margin-bottom: 1rem;
+        font-size: 1.3em;
+    }
+
+    .committee-buttons {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1rem;
+    }
+
+    .committee-btn {
+        background: rgba(255, 255, 255, 0.2);
+        color: white;
+        border: 2px solid rgba(255, 255, 255, 0.3);
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        cursor: pointer;
+        font-weight: 600;
+        transition: all 0.3s ease;
+    }
+
+    .committee-btn:hover {
+        background: rgba(255, 255, 255, 0.3);
+        transform: translateY(-2px);
+    }
+
+    .committee-btn.danger {
+        background: rgba(220, 53, 69, 0.2);
+        border-color: rgba(220, 53, 69, 0.3);
+    }
+
+    .committee-btn.danger:hover {
+        background: rgba(220, 53, 69, 0.3);
+    }
+
     @media (max-width: 700px) {
         .profile-container {
             padding: 15px;
@@ -272,40 +337,143 @@ $logs = $stmt->fetchAll();
                     </ul>
                     <?php endif; ?>
                 </div>
+                <?php if ($is_committee): ?>
+                <div class="committee-actions">
+                    <h3><i class="fas fa-user-shield"></i> Actions de Comité</h3>
+                    <div class="committee-buttons">
+                        <button class="committee-btn" onclick="openModal('startCandModal')">
+                            <i class="fas fa-user-plus"></i> Démarrer Candidatures
+                        </button>
+                        <button class="committee-btn danger" onclick="openModal('closeCandModal')">
+                            <i class="fas fa-times-circle"></i> Fermer Candidatures
+                        </button>
+                        <button class="committee-btn" onclick="openModal('startVoteModal')">
+                            <i class="fas fa-vote-yea"></i> Démarrer Votes
+                        </button>
+                        <button class="committee-btn danger" onclick="openModal('closeVoteModal')">
+                            <i class="fas fa-stop-circle"></i> Fermer Votes
+                        </button>
+                    </div>
+                </div>
+                <?php endif; ?>
             </div>
         </section>
     </div>
 
-    <!-- Modal pour démarrer les votes (pour le footer) -->
-    <div id="startVotesModal" class="modal">
+    <!-- Modal pour démarrer les candidatures -->
+    <div id="startCandModal" class="modal">
         <div class="modal-content">
-            <div class="modal-header">
-                <h2><i class="fas fa-play-circle"></i> Démarrer une Élection</h2>
-                <span class="close-btn" onclick="closeStartVotesModal()">&times;</span>
+            <span class="close-btn" onclick="closeModal('startCandModal')">&times;</span>
+            <h3><i class="fas fa-user-plus"></i> Démarrer les Candidatures</h3>
+            <div class="form-group">
+                <label for="candType">Type d'élection</label>
+                <select id="candType">
+                    <option value="" selected disabled>Choisir un type</option>
+                    <?php foreach ($election_types as $type): ?>
+                    <option value="<?php echo $type['id']; ?>"><?php echo htmlspecialchars($type['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
             </div>
-            <div class="modal-body">
-                <p>Cette fonctionnalité est disponible depuis le Dashboard.</p>
-                <div class="modal-actions">
-                    <button class="admin-btn" onclick="closeStartVotesModal()">Fermer</button>
-                    <button class="admin-btn" onclick="window.location.href='dashboard.php'">Aller au Dashboard</button>
-                </div>
+            <div class="form-group" id="clubGroup" style="display:none;">
+                <label for="clubSelect">Club</label>
+                <select id="clubSelect">
+                    <option value="">-- Sélectionnez un club --</option>
+                    <?php foreach ($clubs as $club): ?>
+                    <option value="<?php echo $club['id']; ?>"><?php echo htmlspecialchars($club['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="startCandDate">Date et heure de début</label>
+                <input type="datetime-local" id="startCandDate">
+            </div>
+            <div class="form-group">
+                <label for="endCandDate">Date et heure de fin</label>
+                <input type="datetime-local" id="endCandDate">
+            </div>
+            <div class="form-actions">
+                <button class="committee-btn danger" onclick="closeModal('startCandModal')">Annuler</button>
+                <button class="committee-btn" onclick="startCandidature()">Valider</button>
             </div>
         </div>
     </div>
 
-    <!-- Modal pour démarrer les candidatures (pour le footer) -->
-    <div id="startCandModal" class="modal">
+    <!-- Modal pour fermer les candidatures -->
+    <div id="closeCandModal" class="modal">
         <div class="modal-content">
-            <div class="modal-header">
-                <h2><i class="fas fa-user-plus"></i> Ouvrir les Candidatures</h2>
-                <span class="close-btn" onclick="closeStartCandModal()">&times;</span>
+            <span class="close-btn" onclick="closeModal('closeCandModal')">&times;</span>
+            <h3><i class="fas fa-times-circle"></i> Fermer les Candidatures</h3>
+            <div class="form-group">
+                <label for="closeCandType">Type d'élection</label>
+                <select id="closeCandType">
+                    <option value="" selected disabled>Choisir un type</option>
+                    <?php foreach ($election_types as $type): ?>
+                    <option value="<?php echo $type['id']; ?>"><?php echo htmlspecialchars($type['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
             </div>
-            <div class="modal-body">
-                <p>Cette fonctionnalité est disponible depuis le Dashboard.</p>
-                <div class="modal-actions">
-                    <button class="admin-btn" onclick="closeStartCandModal()">Fermer</button>
-                    <button class="admin-btn" onclick="window.location.href='dashboard.php'">Aller au Dashboard</button>
-                </div>
+            <div class="form-actions">
+                <button class="committee-btn danger" onclick="closeModal('closeCandModal')">Annuler</button>
+                <button class="committee-btn" onclick="closeCandidature()">Valider</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal pour démarrer les votes -->
+    <div id="startVoteModal" class="modal">
+        <div class="modal-content">
+            <span class="close-btn" onclick="closeModal('startVoteModal')">&times;</span>
+            <h3><i class="fas fa-vote-yea"></i> Démarrer les Votes</h3>
+            <div class="form-group">
+                <label for="voteType">Type d'élection</label>
+                <select id="voteType">
+                    <option value="" selected disabled>Choisir un type</option>
+                    <?php foreach ($election_types as $type): ?>
+                    <option value="<?php echo $type['id']; ?>"><?php echo htmlspecialchars($type['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-group" id="voteClubGroup" style="display:none;">
+                <label for="voteClubSelect">Club</label>
+                <select id="voteClubSelect">
+                    <option value="">-- Sélectionnez un club --</option>
+                    <?php foreach ($clubs as $club): ?>
+                    <option value="<?php echo $club['id']; ?>"><?php echo htmlspecialchars($club['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="startVoteDate">Date et heure de début</label>
+                <input type="datetime-local" id="startVoteDate">
+            </div>
+            <div class="form-group">
+                <label for="endVoteDate">Date et heure de fin</label>
+                <input type="datetime-local" id="endVoteDate">
+            </div>
+            <div class="form-actions">
+                <button class="committee-btn danger" onclick="closeModal('startVoteModal')">Annuler</button>
+                <button class="committee-btn" onclick="startVote()">Valider</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal pour fermer les votes -->
+    <div id="closeVoteModal" class="modal">
+        <div class="modal-content">
+            <span class="close-btn" onclick="closeModal('closeVoteModal')">&times;</span>
+            <h3><i class="fas fa-stop-circle"></i> Fermer les Votes</h3>
+            <div class="form-group">
+                <label for="closeVoteType">Type d'élection</label>
+                <select id="closeVoteType">
+                    <option value="" selected disabled>Choisir un type</option>
+                    <?php foreach ($election_types as $type): ?>
+                    <option value="<?php echo $type['id']; ?>"><?php echo htmlspecialchars($type['name']); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-actions">
+                <button class="committee-btn danger" onclick="closeModal('closeVoteModal')">Annuler</button>
+                <button class="committee-btn" onclick="closeVote()">Valider</button>
             </div>
         </div>
     </div>
@@ -316,37 +484,79 @@ $logs = $stmt->fetchAll();
     <script src="../assets/js/admin_accueil.js"></script>
 
     <script>
-        // Fonctions pour les modals du footer
-        function closeStartVotesModal() {
-            document.getElementById('startVotesModal').style.display = 'none';
-        }
+    function openModal(id) {
+        document.getElementById(id).style.display = 'flex';
+    }
 
-        function closeStartCandModal() {
-            document.getElementById('startCandModal').style.display = 'none';
-        }
+    function closeModal(id) {
+        document.getElementById(id).style.display = 'none';
+    }
 
-        // Fermer les modals en cliquant à l'extérieur
-        window.addEventListener('click', (event) => {
-            const startVotesModal = document.getElementById('startVotesModal');
-            const startCandModal = document.getElementById('startCandModal');
-            
-            if (event.target === startVotesModal) {
-                closeStartVotesModal();
-            }
-            if (event.target === startCandModal) {
-                closeStartCandModal();
-            }
-        });
+    document.getElementById('candType')?.addEventListener('change', (e) => {
+        document.getElementById('clubGroup').style.display = (e.target.value == 2) ? 'block' : 'none';
+    });
 
-        function logout() {
-            if (confirm('Êtes-vous sûr de vouloir vous déconnecter ?')) {
-                window.location.href = '../logout.php';
-            }
-        }
+    document.getElementById('voteType')?.addEventListener('change', (e) => {
+        document.getElementById('voteClubGroup').style.display = (e.target.value == 2) ? 'block' : 'none';
+    });
 
-        function showNotification(msg, type) {
-            alert(msg); // Remplacer par une vraie notification si besoin
+    function startCandidature() {
+        const typeId = document.getElementById('candType').value;
+        const clubId = document.getElementById('clubSelect').value;
+        const startDate = document.getElementById('startCandDate').value;
+        const endDate = document.getElementById('endCandDate').value;
+        if (!typeId || !startDate || !endDate) { alert('Veuillez remplir tous les champs obligatoires'); return; }
+        if (typeId == 2 && !clubId) { alert('Veuillez sélectionner un club'); return; }
+        fetch('actions.php', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            body: `action=start_candidature_session&election_type_id=${typeId}&club_id=${clubId}&start_time=${startDate}&end_time=${endDate}`
+        }).then(r=>r.json()).then(d=>{ if(d.success){alert('Session de candidature démarrée'); closeModal('startCandModal'); location.reload(); } else { alert('Erreur: '+d.message); } });
+    }
+
+    function closeCandidature() {
+        const typeId = document.getElementById('closeCandType').value;
+        if (!typeId) { alert('Veuillez sélectionner un type d\'élection'); return; }
+        if (confirm('Êtes-vous sûr de vouloir fermer les candidatures ?')) {
+            fetch('actions.php', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: `action=close_candidature_session&election_type_id=${typeId}`
+            }).then(r=>r.json()).then(d=>{ if(d.success){alert('Session de candidature fermée'); closeModal('closeCandModal'); location.reload(); } else { alert('Erreur: '+d.message); } });
         }
+    }
+
+    function startVote() {
+        const typeId = document.getElementById('voteType').value;
+        const clubId = document.getElementById('voteClubSelect').value;
+        const startDate = document.getElementById('startVoteDate').value;
+        const endDate = document.getElementById('endVoteDate').value;
+        if (!typeId || !startDate || !endDate) { alert('Veuillez remplir tous les champs obligatoires'); return; }
+        if (typeId == 2 && !clubId) { alert('Veuillez sélectionner un club'); return; }
+        fetch('actions.php', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            body: `action=start_vote_session&election_type_id=${typeId}&club_id=${clubId}&start_time=${startDate}&end_time=${endDate}`
+        }).then(r=>r.json()).then(d=>{ if(d.success){alert('Session de vote démarrée'); closeModal('startVoteModal'); location.reload(); } else { alert('Erreur: '+d.message); } });
+    }
+
+    function closeVote() {
+        const typeId = document.getElementById('closeVoteType').value;
+        if (!typeId) { alert('Veuillez sélectionner un type d\'élection'); return; }
+        if (confirm('Êtes-vous sûr de vouloir fermer les votes ?')) {
+            fetch('actions.php', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: `action=close_vote_session&election_type_id=${typeId}`
+            }).then(r=>r.json()).then(d=>{ if(d.success){alert('Session de vote fermée'); closeModal('closeVoteModal'); location.reload(); } else { alert('Erreur: '+d.message); } });
+        }
+    }
+
+    window.onclick = function(e){ if(e.target.classList.contains('modal')) e.target.style.display='none'; }
+
+    function logout(){ if(confirm('Êtes-vous sûr de vouloir vous déconnecter ?')) window.location.href='../logout.php'; }
+
+    function showNotification(msg,type){ alert(msg); }
     </script>
 </body>
 


### PR DESCRIPTION
## Summary
- allow committee members to use admin actions
- restrict actions to assigned election types
- add committee action buttons on admin profile page
- implement modals and JS handlers for committee controls

## Testing
- `php -l ensae/admin/actions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b37ad139883258daa7a0e5c66da93